### PR TITLE
Feature/add reaming usecases

### DIFF
--- a/app/src/main/java/com/rssfeed/App.kt
+++ b/app/src/main/java/com/rssfeed/App.kt
@@ -42,7 +42,7 @@ class App : Application(), KoinComponent {
   private fun enqueueSyncDataWorker() {
     workManager.enqueueUniquePeriodicWork(
       SYNC_DATA_WORKER_NAME,
-      ExistingPeriodicWorkPolicy.REPLACE,
+      ExistingPeriodicWorkPolicy.UPDATE,
       PeriodicWorkRequestBuilder<SyncDataWorker>(
         SYNC_DATA_WORKER_PERIOD,
         TimeUnit.HOURS,

--- a/data/src/main/java/com/rssfeed/data/db/ChannelDao.kt
+++ b/data/src/main/java/com/rssfeed/data/db/ChannelDao.kt
@@ -16,5 +16,9 @@ interface ChannelDao {
 
   suspend fun deleteChannel(link: String)
 
+  suspend fun toggleFavoriteChannel(link: String, isFavorite: Long)
+
+  suspend fun toggleSubscribedChannel(link: String, isSubscribed: Long)
+
   fun observeFavoriteChannels(): Flow<List<ChannelEntity>>
 }

--- a/data/src/main/java/com/rssfeed/data/db/ChannelDaoImpl.kt
+++ b/data/src/main/java/com/rssfeed/data/db/ChannelDaoImpl.kt
@@ -40,6 +40,18 @@ class ChannelDaoImpl(
 
   override suspend fun deleteChannel(link: String) = channelQueries.deleteChannel(link)
 
+  override suspend fun toggleFavoriteChannel(link: String, isFavorite: Long) =
+    channelQueries.toggleFavoriteChannel(
+      link = link,
+      isFavorite = isFavorite,
+    )
+
+  override suspend fun toggleSubscribedChannel(link: String, isSubscribed: Long) =
+    channelQueries.toggleSubscribedChannel(
+      link = link,
+      isSubscribed = isSubscribed,
+    )
+
   override fun observeFavoriteChannels() =
     channelQueries.getFavoriteChannels().asFlow().mapToList(dispatchers.io)
 }

--- a/data/src/main/java/com/rssfeed/data/repository/RssFeedRepositoryExt.kt
+++ b/data/src/main/java/com/rssfeed/data/repository/RssFeedRepositoryExt.kt
@@ -12,6 +12,7 @@ fun ChannelEntity.toChannelItem() = ChannelItem(
   imageUrl = imageUrl,
   lastBuildDate = lastBuildDate,
   isFavorite = isFavorite,
+  isSubscribed = isSubscribed,
 )
 
 fun List<ChannelEntity>.toChannelItems() = map { it.toChannelItem() }

--- a/data/src/main/java/com/rssfeed/data/repository/RssFeedRepositoryImpl.kt
+++ b/data/src/main/java/com/rssfeed/data/repository/RssFeedRepositoryImpl.kt
@@ -46,6 +46,24 @@ class RssFeedRepositoryImpl(
     }
   }
 
+  override suspend fun toggleFavoriteChannel(link: String, isFavorite: Long): Boolean {
+    return try {
+      channelDao.toggleFavoriteChannel(link, isFavorite)
+      true
+    } catch (e: Exception) {
+      false
+    }
+  }
+
+  override suspend fun toggleSubscribedChannel(link: String, isSubscribed: Long): Boolean {
+    return try {
+      channelDao.toggleSubscribedChannel(link, isSubscribed)
+      true
+    } catch (e: Exception) {
+      false
+    }
+  }
+
   override fun observeFavoriteChannels(): Flow<List<ChannelItem>> =
     channelDao.observeFavoriteChannels().map { it.toChannelItems() }
 

--- a/data/src/main/sqldelight/com/rssfeed/data/schema/ArticleEntity.sq
+++ b/data/src/main/sqldelight/com/rssfeed/data/schema/ArticleEntity.sq
@@ -9,7 +9,7 @@ CREATE TABLE articleEntity(
 );
 
 getArticlesByChannelLink:
-SELECT * FROM articleEntity WHERE channelLink = ?;
+SELECT * FROM articleEntity WHERE channelLink = ? ORDER BY pubDate DESC;
 
 insertArticle:
 INSERT OR REPLACE INTO articleEntity VALUES (?, ?, ?, ?, ?, ?);

--- a/data/src/main/sqldelight/com/rssfeed/data/schema/ChannelEntity.sq
+++ b/data/src/main/sqldelight/com/rssfeed/data/schema/ChannelEntity.sq
@@ -10,7 +10,7 @@ CREATE TABLE channelEntity(
 );
 
 getChannels:
-SELECT * FROM channelEntity;
+SELECT * FROM channelEntity ORDER BY title ASC;
 
 insertChannel:
 INSERT OR REPLACE INTO channelEntity VALUES (?, ?, ?, ?, ?, ?, ?, ?);
@@ -19,7 +19,7 @@ deleteChannel:
 DELETE FROM channelEntity WHERE link = ?;
 
 getFavoriteChannels:
-SELECT * FROM channelEntity WHERE isFavorite = 0;
+SELECT * FROM channelEntity WHERE isFavorite = 0 ORDER BY title ASC;
 
 toggleFavoriteChannel:
 UPDATE channelEntity SET isFavorite = ? WHERE link = ?;

--- a/data/src/main/sqldelight/com/rssfeed/data/schema/ChannelEntity.sq
+++ b/data/src/main/sqldelight/com/rssfeed/data/schema/ChannelEntity.sq
@@ -20,3 +20,9 @@ DELETE FROM channelEntity WHERE link = ?;
 
 getFavoriteChannels:
 SELECT * FROM channelEntity WHERE isFavorite = 0;
+
+toggleFavoriteChannel:
+UPDATE channelEntity SET isFavorite = ? WHERE link = ?;
+
+toggleSubscribedChannel:
+UPDATE channelEntity SET isSubscribed = ? WHERE link = ?;

--- a/domain/src/main/java/com/rssfeed/domain/di/UseCaseModule.kt
+++ b/domain/src/main/java/com/rssfeed/domain/di/UseCaseModule.kt
@@ -6,6 +6,8 @@ import com.rssfeed.domain.usecase.ObserveArticles
 import com.rssfeed.domain.usecase.ObserveChannels
 import com.rssfeed.domain.usecase.ObserveFavoriteChannels
 import com.rssfeed.domain.usecase.SyncAndGetUpdatedSubscribedChannelTitles
+import com.rssfeed.domain.usecase.ToggleFavoriteChannel
+import com.rssfeed.domain.usecase.ToggleSubscribedChannel
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
@@ -15,5 +17,7 @@ val useCaseModule = module {
   factoryOf(::ObserveArticles)
   factoryOf(::ObserveChannels)
   factoryOf(::ObserveFavoriteChannels)
+  factoryOf(::ToggleFavoriteChannel)
+  factoryOf(::ToggleSubscribedChannel)
   factoryOf(::SyncAndGetUpdatedSubscribedChannelTitles)
 }

--- a/domain/src/main/java/com/rssfeed/domain/model/ChannelItem.kt
+++ b/domain/src/main/java/com/rssfeed/domain/model/ChannelItem.kt
@@ -7,4 +7,5 @@ data class ChannelItem(
   val imageUrl: String,
   val lastBuildDate: String,
   val isFavorite: Long,
+  val isSubscribed: Long,
 )

--- a/domain/src/main/java/com/rssfeed/domain/repository/RssFeedRepository.kt
+++ b/domain/src/main/java/com/rssfeed/domain/repository/RssFeedRepository.kt
@@ -14,6 +14,10 @@ interface RssFeedRepository {
 
   suspend fun deleteChannel(link: String): Boolean
 
+  suspend fun toggleFavoriteChannel(link: String, isFavorite: Long): Boolean
+
+  suspend fun toggleSubscribedChannel(link: String, isSubscribed: Long): Boolean
+
   fun observeFavoriteChannels(): Flow<List<ChannelItem>>
 
   fun observeArticlesByChannelLink(channelLink: String): Flow<List<ArticleItem>>

--- a/domain/src/main/java/com/rssfeed/domain/usecase/ToggleFavoriteChannel.kt
+++ b/domain/src/main/java/com/rssfeed/domain/usecase/ToggleFavoriteChannel.kt
@@ -1,0 +1,16 @@
+package com.rssfeed.domain.usecase
+
+import com.rssfeed.domain.repository.RssFeedRepository
+
+class ToggleFavoriteChannel(
+  private val rssFeedRepository: RssFeedRepository,
+) {
+
+  suspend operator fun invoke(
+    link: String,
+    isFavorite: Boolean,
+  ) = rssFeedRepository.toggleFavoriteChannel(
+    link = link,
+    isFavorite = if (isFavorite) 1L else 0L,
+  )
+}

--- a/domain/src/main/java/com/rssfeed/domain/usecase/ToggleSubscribedChannel.kt
+++ b/domain/src/main/java/com/rssfeed/domain/usecase/ToggleSubscribedChannel.kt
@@ -1,0 +1,16 @@
+package com.rssfeed.domain.usecase
+
+import com.rssfeed.domain.repository.RssFeedRepository
+
+class ToggleSubscribedChannel(
+  private val rssFeedRepository: RssFeedRepository,
+) {
+
+  suspend operator fun invoke(
+    link: String,
+    isSubscribed: Boolean,
+  ) = rssFeedRepository.toggleSubscribedChannel(
+    link = link,
+    isSubscribed = if (isSubscribed) 1L else 0L,
+  )
+}


### PR DESCRIPTION
- Added ToggleSubscribedChannelLogic to handle subscribing/unsubscribing to channels.
- Added ToggleFavoriteChannelLogic to manage favoriting/unfavoriting channels.
- Implemented ordering logic for channels and articles:
- Channels are sorted alphabetically by title.
- Articles are sorted by pubDate (newest first).
- Updated relevant queries and repository logic.